### PR TITLE
chore: update line-bot-sdk-go to version 8.2.0 and replace linebot wi…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,4 +3,4 @@ module github.com/kkdai/LineBotTemplate
 // +heroku goVersion go1.21
 go 1.21
 
-require github.com/line/line-bot-sdk-go/v7 v7.21.0
+require github.com/line/line-bot-sdk-go/v8 v8.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/line/line-bot-sdk-go/v7 v7.21.0 h1:eeYMuAwaDV5DZNTRqDipNhzjT51HwEcM1PRPG+cqh4Y=
-github.com/line/line-bot-sdk-go/v7 v7.21.0/go.mod h1:idpoxOZgtSd8JyhctMMpwg5LNgRAIL/QIxa5S0DXcMg=
+github.com/line/line-bot-sdk-go/v8 v8.2.0 h1:IFqwd3pKbA+o3pwV3nzamtWHt7n+ijSH3t/D8Q/vVQ0=
+github.com/line/line-bot-sdk-go/v8 v8.2.0/go.mod h1:n9Ly8OHM6xCeQktLzRpQHe/yBda95kFgmQUefUQeFCs=


### PR DESCRIPTION
…th webhook in main.go

- Update the required version of `github.com/line/line-bot-sdk-go` from v7.21.0 to v8.2.0 in go.mod
- Update the import statements in main.go to use `github.com/line/line-bot-sdk-go/v8/linebot` and `github.com/line/line-bot-sdk-go/v8/linebot/webhook`
- Replace `bot.ParseRequest` with `webhook.ParseRequest` in the callbackHandler function
- Replace the switch cases for `linebot.TextMessage` and `linebot.StickerMessage` with the corresponding cases for `webhook.TextMessageContent` and `webhook.StickerMessageContent` in the callbackHandler function
- Add cases for `webhook.MessageEvent`, `webhook.FollowEvent`, `webhook.PostbackEvent`, and `webhook.BeaconEvent` in the callbackHandler function